### PR TITLE
Continue if member resolving fails

### DIFF
--- a/Get-MicrosoftTeamsChat.ps1
+++ b/Get-MicrosoftTeamsChat.ps1
@@ -89,7 +89,14 @@ foreach ($chat in $chats) {
     
     Write-Verbose "Exporting $($chat.id)"
 
-    $members = Get-Members $chat $clientId $tenantId
+    try {
+        $members = Get-Members $chat $clientId $tenantId
+    }
+    catch {
+        Write-Host ("Members could not resolved, continue...")
+        continue
+    }
+
     $name = ConvertTo-ChatName $chat $members $me $clientId $tenantId
     
     


### PR DESCRIPTION
For whatever reason the statement in `functions\chat\Get-Members.psm1`

```powershell
Invoke-RestMethod -Method Get -Uri $membersUri -Headers @{
    "Authorization" = "Bearer $(Get-GraphAccessToken $clientId $tenantId)"
```

crashed and due to the re-throwing in line 20 the whole script stopped working.

This contribution catches this issue and continues the processing.